### PR TITLE
Added support for modern Architect and Connect modules

### DIFF
--- a/configs/default.js
+++ b/configs/default.js
@@ -1,9 +1,6 @@
 var port = process.env.PORT || 8080;
 
-module.exports = {
-    containers: {
-        master: {
-            plugins: [{
+module.exports = [{
                 packagePath: "../connect",
                 port: port
             }, {
@@ -14,7 +11,4 @@ module.exports = {
                 packagePath: "../connect.session.memory"
             }, {
                 packagePath: "architect/plugins/architect.log"
-            }]
-        }
-    }
-};
+            }];

--- a/connect.session.file/session-ext.js
+++ b/connect.session.file/session-ext.js
@@ -21,6 +21,7 @@ module.exports = function startup(options, imports, register) {
     
     register(null, {
         "session-store": {
+            on: sessionStore.on.bind(sessionStore),
             get: sessionStore.get.bind(sessionStore),
             set: sessionStore.set.bind(sessionStore),
             destroy: sessionStore.destroy.bind(sessionStore),

--- a/connect.session.memory/session-ext.js
+++ b/connect.session.memory/session-ext.js
@@ -6,6 +6,7 @@ module.exports = function startup(options, imports, register) {
 
     register(null, {
         "session-store": {
+            on: sessionStore.on.bind(sessionStore),
             get: sessionStore.get.bind(sessionStore),
             set: sessionStore.set.bind(sessionStore),
             destroy: sessionStore.destroy.bind(sessionStore),

--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
         }
     ],
     "dependencies": {
-        "architect": "~0.0.3",
-        "connect": "~1.8.7",
+        "architect": "~0.1.4",
+        "connect": "~2.4.5",
         "netutil": "~0.0.1",
         "mime": ">= 0.0.1"
     },

--- a/server.js
+++ b/server.js
@@ -5,8 +5,8 @@ var architect = require("architect");
 
 var configName = process.argv[2] || "default";
 var configPath = path.resolve("./configs/", configName);
-
-architect.createApp(configPath, function (err, app) {
+var config = architect.loadConfig(configPath);
+architect.createApp(config, function (err, app) {
     if (err) {
         console.error("While starting the '%s':", configPath);
         throw err;


### PR DESCRIPTION
These changes relate to new requirements for Connect message-store objects, and the (processed) object form of Architect app configuration files. It basically consists of three one-liners plus removal of containers from the app configuration file, and updated package.json to pull modern versions of Architect and Connect modules.
