### PR TITLE
The requested update for Connect forward compatibility without impacting backward compatibly

### DIFF
--- a/connect.session.file/session-ext.js
+++ b/connect.session.file/session-ext.js
@@ -21,7 +21,7 @@ module.exports = function startup(options, imports, register) {
     
     register(null, {
         "session-store": {
-//            on: sessionStore.on.bind(sessionStore),
+            on: sessionStore.on.bind(sessionStore),
             get: sessionStore.get.bind(sessionStore),
             set: sessionStore.set.bind(sessionStore),
             destroy: sessionStore.destroy.bind(sessionStore),

--- a/connect.session.memory/session-ext.js
+++ b/connect.session.memory/session-ext.js
@@ -6,7 +6,7 @@ module.exports = function startup(options, imports, register) {
 
     register(null, {
         "session-store": {
-//            on: sessionStore.on.bind(sessionStore),
+            on: sessionStore.on.bind(sessionStore),
             get: sessionStore.get.bind(sessionStore),
             set: sessionStore.set.bind(sessionStore),
             destroy: sessionStore.destroy.bind(sessionStore),


### PR DESCRIPTION
This facilitates support of Connect 2.4.5+ without impacting backward compatibility. The dependency for Connect v1.8.7 is retained in package.json due to issues elsewhere in the cloud9ide stack, but users of the connect-architect layer independantly, may update to Connect v2.4.5+ without issue
